### PR TITLE
Add trailers to movie details screen

### DIFF
--- a/core/data/src/commonMain/kotlin/com/elna/moviedb/core/data/model/Movies.kt
+++ b/core/data/src/commonMain/kotlin/com/elna/moviedb/core/data/model/Movies.kt
@@ -13,7 +13,7 @@ fun RemoteMovie.asEntity() = MovieEntity(
     id = id,
     timestamp = Clock.System.now().epochSeconds,
     title = title,
-    poster_path = "$TMDB_IMAGE_URL$posterPath"
+    posterPath = "$TMDB_IMAGE_URL$posterPath"
 )
 
 

--- a/core/data/src/commonMain/kotlin/com/elna/moviedb/core/data/movies/MoviesRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/elna/moviedb/core/data/movies/MoviesRepositoryImpl.kt
@@ -5,13 +5,13 @@ import com.elna.moviedb.core.common.AppDispatchers
 import com.elna.moviedb.core.data.model.asEntity
 import com.elna.moviedb.core.database.MoviesLocalDataSource
 import com.elna.moviedb.core.database.model.MovieCategory
+import com.elna.moviedb.core.database.model.asEntity
 import com.elna.moviedb.core.datastore.PreferencesManager
 import com.elna.moviedb.core.datastore.model.PaginationState
 import com.elna.moviedb.core.model.AppLanguage
 import com.elna.moviedb.core.model.AppResult
 import com.elna.moviedb.core.model.Movie
 import com.elna.moviedb.core.model.MovieDetails
-import com.elna.moviedb.core.database.model.asEntity
 import com.elna.moviedb.core.network.MoviesRemoteDataSource
 import com.elna.moviedb.core.network.model.videos.RemoteVideo
 import com.elna.moviedb.core.network.model.videos.toDomain
@@ -73,13 +73,12 @@ class MoviesRepositoryImpl(
      * Automatically triggers initial load if cache is empty.
      */
     override suspend fun observePopularMovies(): Flow<List<Movie>> {
-        val localMoviesPageStream = moviesLocalDataSource.getMoviesByCategoryAsFlow(MovieCategory.POPULAR.name)
+        val localMoviesPageStream =
+            moviesLocalDataSource.getMoviesByCategoryAsFlow(MovieCategory.POPULAR.name)
 
-        // Load initial data if empty (non-blocking)
-        repositoryScope.launch {
-            if (localMoviesPageStream.first().isEmpty()) {
-                loadPopularMoviesNextPage()
-            }
+        // Load initial data if empty
+        if (localMoviesPageStream.first().isEmpty()) {
+            loadPopularMoviesNextPage()
         }
 
         return localMoviesPageStream.map { movieEntities ->
@@ -99,13 +98,12 @@ class MoviesRepositoryImpl(
      * Automatically triggers initial load if cache is empty.
      */
     override suspend fun observeTopRatedMovies(): Flow<List<Movie>> {
-        val localMoviesPageStream = moviesLocalDataSource.getMoviesByCategoryAsFlow(MovieCategory.TOP_RATED.name)
+        val localMoviesPageStream =
+            moviesLocalDataSource.getMoviesByCategoryAsFlow(MovieCategory.TOP_RATED.name)
 
-        // Load initial data if empty (non-blocking)
-        repositoryScope.launch {
-            if (localMoviesPageStream.first().isEmpty()) {
-                loadTopRatedMoviesNextPage()
-            }
+        // Load initial data if empty
+        if (localMoviesPageStream.first().isEmpty()) {
+            loadTopRatedMoviesNextPage()
         }
 
         return localMoviesPageStream.map { movieEntities ->
@@ -125,13 +123,12 @@ class MoviesRepositoryImpl(
      * Automatically triggers initial load if cache is empty.
      */
     override suspend fun observeNowPlayingMovies(): Flow<List<Movie>> {
-        val localMoviesPageStream = moviesLocalDataSource.getMoviesByCategoryAsFlow(MovieCategory.NOW_PLAYING.name)
+        val localMoviesPageStream =
+            moviesLocalDataSource.getMoviesByCategoryAsFlow(MovieCategory.NOW_PLAYING.name)
 
-        // Load initial data if empty (non-blocking)
-        repositoryScope.launch {
-            if (localMoviesPageStream.first().isEmpty()) {
-                loadNowPlayingMoviesNextPage()
-            }
+        // Load initial data if empty
+        if (localMoviesPageStream.first().isEmpty()) {
+            loadNowPlayingMoviesNextPage()
         }
 
         return localMoviesPageStream.map { movieEntities ->
@@ -160,7 +157,8 @@ class MoviesRepositoryImpl(
 
         val nextPage = paginationState.currentPage + 1
 
-        return when (val result = moviesRemoteDataSource.getPopularMoviesPage(nextPage, currentLanguage)) {
+        return when (val result =
+            moviesRemoteDataSource.getPopularMoviesPage(nextPage, currentLanguage)) {
             is AppResult.Success -> {
                 val newTotalPages = result.data.totalPages
                 val entities = result.data.results.map {
@@ -198,7 +196,8 @@ class MoviesRepositoryImpl(
 
         val nextPage = paginationState.currentPage + 1
 
-        return when (val result = moviesRemoteDataSource.getTopRatedMoviesPage(nextPage, currentLanguage)) {
+        return when (val result =
+            moviesRemoteDataSource.getTopRatedMoviesPage(nextPage, currentLanguage)) {
             is AppResult.Success -> {
                 val newTotalPages = result.data.totalPages
                 val entities = result.data.results.map {
@@ -236,7 +235,8 @@ class MoviesRepositoryImpl(
 
         val nextPage = paginationState.currentPage + 1
 
-        return when (val result = moviesRemoteDataSource.getNowPlayingMoviesPage(nextPage, currentLanguage)) {
+        return when (val result =
+            moviesRemoteDataSource.getNowPlayingMoviesPage(nextPage, currentLanguage)) {
             is AppResult.Success -> {
                 val newTotalPages = result.data.totalPages
                 val entities = result.data.results.map {
@@ -309,6 +309,7 @@ class MoviesRepositoryImpl(
                     .take(10)
                     .map { it.toDomain() }
             }
+
             is AppResult.Error -> emptyList()  // Graceful degradation
         }
 
@@ -363,9 +364,12 @@ class MoviesRepositoryImpl(
         }
 
         // All succeeded - return combined list from local storage
-        val popularMovies = moviesLocalDataSource.getMoviesByCategoryAsFlow(MovieCategory.POPULAR.name).first()
-        val topRatedMovies = moviesLocalDataSource.getMoviesByCategoryAsFlow(MovieCategory.TOP_RATED.name).first()
-        val nowPlayingMovies = moviesLocalDataSource.getMoviesByCategoryAsFlow(MovieCategory.NOW_PLAYING.name).first()
+        val popularMovies =
+            moviesLocalDataSource.getMoviesByCategoryAsFlow(MovieCategory.POPULAR.name).first()
+        val topRatedMovies =
+            moviesLocalDataSource.getMoviesByCategoryAsFlow(MovieCategory.TOP_RATED.name).first()
+        val nowPlayingMovies =
+            moviesLocalDataSource.getMoviesByCategoryAsFlow(MovieCategory.NOW_PLAYING.name).first()
 
         val combinedList = (popularMovies + topRatedMovies + nowPlayingMovies).map {
             Movie(id = it.id, title = it.title, poster_path = it.poster_path)

--- a/core/database/schemas/com.elna.moviedb.core.database.AppDatabase/1.json
+++ b/core/database/schemas/com.elna.moviedb.core.database.AppDatabase/1.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "f3f7dc1b4dda750f2608ba224b09089f",
+    "identityHash": "d9aedf7b71db155dc833389e6719bd94",
     "entities": [
       {
         "tableName": "MovieEntity",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `title` TEXT NOT NULL, `poster_path` TEXT, `category` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `title` TEXT NOT NULL, `posterPath` TEXT, `category` TEXT NOT NULL, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -27,8 +27,8 @@
             "notNull": true
           },
           {
-            "fieldPath": "poster_path",
-            "columnName": "poster_path",
+            "fieldPath": "posterPath",
+            "columnName": "posterPath",
             "affinity": "TEXT"
           },
           {
@@ -177,7 +177,7 @@
       },
       {
         "tableName": "videos",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `movie_id` INTEGER NOT NULL, `key` TEXT NOT NULL, `name` TEXT NOT NULL, `site` TEXT NOT NULL, `type` TEXT NOT NULL, `official` INTEGER NOT NULL, `published_at` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`movie_id`) REFERENCES `MovieDetailsEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `movie_id` INTEGER NOT NULL, `key` TEXT NOT NULL, `name` TEXT NOT NULL, `site` TEXT NOT NULL, `type` TEXT NOT NULL, `official` INTEGER NOT NULL, `published_at` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`movie_id`) REFERENCES `MovieDetailsEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
         "fields": [
           {
             "fieldPath": "id",
@@ -261,7 +261,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f3f7dc1b4dda750f2608ba224b09089f')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd9aedf7b71db155dc833389e6719bd94')"
     ]
   }
 }

--- a/core/database/schemas/com.elna.moviedb.core.database.AppDatabase/1.json
+++ b/core/database/schemas/com.elna.moviedb.core.database.AppDatabase/1.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "16d94e981c732fd082628b92e04a485c",
+    "identityHash": "f3f7dc1b4dda750f2608ba224b09089f",
     "entities": [
       {
         "tableName": "MovieEntity",
@@ -174,11 +174,94 @@
             "id"
           ]
         }
+      },
+      {
+        "tableName": "videos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `movie_id` INTEGER NOT NULL, `key` TEXT NOT NULL, `name` TEXT NOT NULL, `site` TEXT NOT NULL, `type` TEXT NOT NULL, `official` INTEGER NOT NULL, `published_at` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`movie_id`) REFERENCES `MovieDetailsEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "movieId",
+            "columnName": "movie_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "site",
+            "columnName": "site",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "official",
+            "columnName": "official",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedAt",
+            "columnName": "published_at",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_videos_movie_id",
+            "unique": false,
+            "columnNames": [
+              "movie_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_videos_movie_id` ON `${TABLE_NAME}` (`movie_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "MovieDetailsEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "movie_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
       }
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '16d94e981c732fd082628b92e04a485c')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f3f7dc1b4dda750f2608ba224b09089f')"
     ]
   }
 }

--- a/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/Database.kt
+++ b/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/Database.kt
@@ -8,12 +8,14 @@ import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import com.elna.moviedb.core.common.AppDispatchers
 import com.elna.moviedb.core.database.model.MovieDetailsEntity
 import com.elna.moviedb.core.database.model.MovieEntity
+import com.elna.moviedb.core.database.model.VideoEntity
 
 
 @Database(
     entities = [
         MovieEntity::class,
-        MovieDetailsEntity::class
+        MovieDetailsEntity::class,
+        VideoEntity::class
     ],
     version = 1
 )

--- a/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/MovieDetailsDao.kt
+++ b/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/MovieDetailsDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.elna.moviedb.core.database.model.MovieDetailsEntity
+import com.elna.moviedb.core.database.model.VideoEntity
 
 @Dao
 interface MovieDetailsDao {
@@ -16,4 +17,13 @@ interface MovieDetailsDao {
 
     @Query("DELETE FROM MovieDetailsEntity")
     suspend fun clearAllMovieDetails()
+
+    @Query("SELECT * FROM videos WHERE movie_id = :movieId")
+    suspend fun getVideosForMovie(movieId: Int): List<VideoEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertVideos(videos: List<VideoEntity>)
+
+    @Query("DELETE FROM videos WHERE movie_id = :movieId")
+    suspend fun deleteVideosForMovie(movieId: Int)
 }

--- a/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/MovieDetailsDao.kt
+++ b/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/MovieDetailsDao.kt
@@ -18,7 +18,7 @@ interface MovieDetailsDao {
     @Query("DELETE FROM MovieDetailsEntity")
     suspend fun clearAllMovieDetails()
 
-    @Query("SELECT * FROM videos WHERE movie_id = :movieId")
+    @Query("SELECT * FROM videos WHERE movie_id = :movieId ORDER BY official DESC, published_at DESC")
     suspend fun getVideosForMovie(movieId: Int): List<VideoEntity>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/MoviesLocalDataSource.kt
+++ b/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/MoviesLocalDataSource.kt
@@ -2,6 +2,7 @@ package com.elna.moviedb.core.database
 
 import com.elna.moviedb.core.database.model.MovieDetailsEntity
 import com.elna.moviedb.core.database.model.MovieEntity
+import com.elna.moviedb.core.database.model.VideoEntity
 import kotlinx.coroutines.flow.Flow
 
 class MoviesLocalDataSource(
@@ -37,5 +38,17 @@ class MoviesLocalDataSource(
     suspend fun clearAllMovies() {
         movieDao.clearAllMovies()
         movieDetailsDao.clearAllMovieDetails()
+    }
+
+    suspend fun getVideosForMovie(movieId: Int): List<VideoEntity> {
+        return movieDetailsDao.getVideosForMovie(movieId)
+    }
+
+    suspend fun insertVideos(videos: List<VideoEntity>) {
+        movieDetailsDao.insertVideos(videos)
+    }
+
+    suspend fun deleteVideosForMovie(movieId: Int) {
+        movieDetailsDao.deleteVideosForMovie(movieId)
     }
 }

--- a/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/model/MovieEntity.kt
+++ b/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/model/MovieEntity.kt
@@ -14,6 +14,6 @@ data class MovieEntity(
     @PrimaryKey val id: Int,
     val timestamp: Long,
     val title: String,
-    val poster_path: String?,
+    val posterPath: String?,
     val category: String = MovieCategory.POPULAR.name
 )

--- a/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/model/VideoEntity.kt
+++ b/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/model/VideoEntity.kt
@@ -15,20 +15,23 @@ import com.elna.moviedb.core.model.VideoSite
             entity = MovieDetailsEntity::class,
             parentColumns = ["id"],
             childColumns = ["movie_id"],
-            onDelete = ForeignKey.CASCADE
+            onDelete = ForeignKey.CASCADE,
+            deferred = true
         )
     ],
     indices = [Index("movie_id")]
 )
 data class VideoEntity(
     @PrimaryKey val id: String,
-    @ColumnInfo(name = "movie_id") val movieId: Int,
+    @ColumnInfo(name = "movie_id")
+    val movieId: Int,
     val key: String,
     val name: String,
     val site: String,
     val type: String,
     val official: Boolean,
-    @ColumnInfo(name = "published_at") val publishedAt: String?
+    @ColumnInfo(name = "published_at")
+    val publishedAt: String?
 ) {
     fun toDomain(): Video = Video(
         id = id,

--- a/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/model/VideoEntity.kt
+++ b/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/model/VideoEntity.kt
@@ -1,0 +1,52 @@
+package com.elna.moviedb.core.database.model
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import com.elna.moviedb.core.model.Video
+import com.elna.moviedb.core.model.VideoSite
+
+@Entity(
+    tableName = "videos",
+    foreignKeys = [
+        ForeignKey(
+            entity = MovieDetailsEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["movie_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("movie_id")]
+)
+data class VideoEntity(
+    @PrimaryKey val id: String,
+    @ColumnInfo(name = "movie_id") val movieId: Int,
+    val key: String,
+    val name: String,
+    val site: String,
+    val type: String,
+    val official: Boolean,
+    @ColumnInfo(name = "published_at") val publishedAt: String?
+) {
+    fun toDomain(): Video = Video(
+        id = id,
+        key = key,
+        name = name,
+        site = VideoSite.fromString(site),
+        type = type,
+        official = official
+    )
+}
+
+fun Video.asEntity(movieId: Int, publishedAt: String? = null): VideoEntity = VideoEntity(
+    id = id,
+    movieId = movieId,
+    key = key,
+    name = name,
+    site = site.name,
+    type = type,
+    official = official,
+    publishedAt = publishedAt
+)

--- a/core/model/src/commonMain/kotlin/com/elna/moviedb/core/model/Movie.kt
+++ b/core/model/src/commonMain/kotlin/com/elna/moviedb/core/model/Movie.kt
@@ -3,5 +3,5 @@ package com.elna.moviedb.core.model
 data class Movie(
     val id: Int,
     val title: String,
-    val poster_path: String?,
+    val posterPath: String?,
 )

--- a/core/model/src/commonMain/kotlin/com/elna/moviedb/core/model/MovieDetails.kt
+++ b/core/model/src/commonMain/kotlin/com/elna/moviedb/core/model/MovieDetails.kt
@@ -1,6 +1,11 @@
 package com.elna.moviedb.core.model
 
-
+/**
+ * Full movie details.
+ *
+ * @property trailers List of official trailer videos (e.g., YouTube). May be null when unavailable.
+ *                    Contains only Trailer-type videos, not teasers/clips.
+ */
 data class MovieDetails(
     val id: Int,
     val title: String,

--- a/core/model/src/commonMain/kotlin/com/elna/moviedb/core/model/MovieDetails.kt
+++ b/core/model/src/commonMain/kotlin/com/elna/moviedb/core/model/MovieDetails.kt
@@ -24,5 +24,6 @@ data class MovieDetails(
     val genres: List<String>?,
     val productionCompanies: List<String>?,
     val productionCountries: List<String>?,
-    val spokenLanguages: List<String>?
+    val spokenLanguages: List<String>?,
+    val trailers: List<Video>? = null
 )

--- a/core/network/src/commonMain/kotlin/com/elna/moviedb/core/network/MoviesRemoteDataSource.kt
+++ b/core/network/src/commonMain/kotlin/com/elna/moviedb/core/network/MoviesRemoteDataSource.kt
@@ -6,6 +6,7 @@ import com.elna.moviedb.core.network.model.TMDB_API_KEY
 import com.elna.moviedb.core.network.model.TMDB_BASE_URL
 import com.elna.moviedb.core.network.model.movies.RemoteMovieDetails
 import com.elna.moviedb.core.network.model.movies.RemoteMoviesPage
+import com.elna.moviedb.core.network.model.videos.RemoteVideoResponse
 import com.elna.moviedb.core.network.utils.safeApiCall
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -36,6 +37,19 @@ class MoviesRemoteDataSource(
                         parameters.append("language", language)
                     }
                 }.body<RemoteMovieDetails>()
+            }
+        }
+    }
+
+    suspend fun getMovieVideos(movieId: Int, language: String): AppResult<RemoteVideoResponse> {
+        return withContext(appDispatchers.io) {
+            safeApiCall {
+                httpClient.get("${TMDB_BASE_URL}movie/${movieId}/videos") {
+                    url {
+                        parameters.append("api_key", TMDB_API_KEY)
+                        parameters.append("language", language)
+                    }
+                }.body<RemoteVideoResponse>()
             }
         }
     }

--- a/core/network/src/commonMain/kotlin/com/elna/moviedb/core/network/MoviesRemoteDataSource.kt
+++ b/core/network/src/commonMain/kotlin/com/elna/moviedb/core/network/MoviesRemoteDataSource.kt
@@ -48,6 +48,7 @@ class MoviesRemoteDataSource(
                     url {
                         parameters.append("api_key", TMDB_API_KEY)
                         parameters.append("language", language)
+                        parameters.append("include_video_language", "$language,null")
                     }
                 }.body<RemoteVideoResponse>()
             }

--- a/core/network/src/commonMain/kotlin/com/elna/moviedb/core/network/model/search/RemoteMultiSearchItem.kt
+++ b/core/network/src/commonMain/kotlin/com/elna/moviedb/core/network/model/search/RemoteMultiSearchItem.kt
@@ -54,7 +54,7 @@ fun RemoteMultiSearchItem.toSearchResult(): SearchResultItem? {
                 movie = Movie(
                     id = id,
                     title = movieTitle,
-                    poster_path = posterPath?.let { TMDB_IMAGE_URL + it }
+                    posterPath = posterPath?.let { TMDB_IMAGE_URL + it }
                 ),
                 overview = overview,
                 releaseDate = releaseDate,

--- a/core/network/src/commonMain/kotlin/com/elna/moviedb/core/network/model/search/RemoteSearchMovie.kt
+++ b/core/network/src/commonMain/kotlin/com/elna/moviedb/core/network/model/search/RemoteSearchMovie.kt
@@ -42,7 +42,7 @@ fun RemoteSearchMovie.toDomain(): Movie {
     return Movie(
         id = id,
         title = title,
-        poster_path = "$TMDB_IMAGE_URL$posterPath"
+        posterPath = "$TMDB_IMAGE_URL$posterPath"
     )
 }
 
@@ -51,7 +51,7 @@ fun RemoteSearchMovie.toSearchResult(): SearchResultItem.MovieItem {
         movie = Movie(
             id = id,
             title = title,
-            poster_path = "$TMDB_IMAGE_URL$posterPath"
+            posterPath = "$TMDB_IMAGE_URL$posterPath"
         ),
         overview = overview,
         releaseDate = releaseDate,

--- a/features/movies/src/commonMain/kotlin/com/elna/moviedb/feature/movies/ui/movie_details/MovieDetailsScreen.kt
+++ b/features/movies/src/commonMain/kotlin/com/elna/moviedb/feature/movies/ui/movie_details/MovieDetailsScreen.kt
@@ -1,6 +1,7 @@
 package com.elna.moviedb.feature.movies.ui.movie_details
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,14 +14,18 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.Language
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -36,9 +41,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.elna.moviedb.core.model.MovieDetails
+import com.elna.moviedb.core.model.Video
 import com.elna.moviedb.core.ui.design_system.AppErrorComponent
 import com.elna.moviedb.core.ui.design_system.AppLoader
 import com.elna.moviedb.core.ui.utils.ImageLoader
@@ -55,6 +62,7 @@ import com.elna.moviedb.resources.rating
 import com.elna.moviedb.resources.release
 import com.elna.moviedb.resources.revenue
 import com.elna.moviedb.resources.runtime
+import com.elna.moviedb.resources.trailers
 import com.elna.moviedb.resources.votes
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -256,6 +264,11 @@ private fun MovieDetailsContent(movie: MovieDetails) {
                 )
             }
 
+            // Trailers Section
+            movie.trailers?.takeIf { it.isNotEmpty() }?.let { trailers ->
+                TrailersSection(trailers = trailers)
+            }
+
             // Genres Section
             movie.genres?.takeIf { it.isNotEmpty() }?.let { genres ->
                 SectionCard(
@@ -413,6 +426,95 @@ private fun BoxOfficeItem(
             fontWeight = FontWeight.SemiBold,
             color = MaterialTheme.colorScheme.primary
         )
+    }
+}
+
+@Composable
+private fun TrailersSection(trailers: List<Video>) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                text = stringResource(Res.string.trailers),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            LazyRow(
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                items(trailers) { trailer ->
+                    TrailerCard(trailer = trailer)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TrailerCard(trailer: Video) {
+    val uriHandler = LocalUriHandler.current
+
+    Card(
+        modifier = Modifier.width(200.dp).padding(2.dp),
+        onClick = { uriHandler.openUri(trailer.getVideoUrl()) },
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(120.dp)
+            ) {
+                ImageLoader(
+                    imageUrl = trailer.getThumbnailUrl(),
+                    modifier = Modifier.fillMaxSize()
+                )
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.Black.copy(alpha = 0.3f)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.PlayArrow,
+                        contentDescription = null,
+                        tint = Color.White,
+                        modifier = Modifier.size(48.dp)
+                    )
+                }
+            }
+
+            Column(
+                modifier = Modifier.padding(8.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    text = trailer.name,
+                    maxLines = 1,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+                AssistChip(
+                    onClick = { },
+                    label = {
+                        Text(
+                            trailer.site.displayName,
+                            style = MaterialTheme.typography.labelSmall
+                        )
+                    }
+                )
+            }
+        }
     }
 }
 

--- a/features/movies/src/commonMain/kotlin/com/elna/moviedb/feature/movies/ui/movie_details/MovieDetailsScreen.kt
+++ b/features/movies/src/commonMain/kotlin/com/elna/moviedb/feature/movies/ui/movie_details/MovieDetailsScreen.kt
@@ -451,7 +451,7 @@ private fun TrailersSection(trailers: List<Video>) {
             LazyRow(
                 horizontalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                items(trailers) { trailer ->
+                items(trailers, key = { it.id }) { trailer ->
                     TrailerCard(trailer = trailer)
                 }
             }

--- a/features/movies/src/commonMain/kotlin/com/elna/moviedb/feature/movies/ui/movies/MovieTile.kt
+++ b/features/movies/src/commonMain/kotlin/com/elna/moviedb/feature/movies/ui/movies/MovieTile.kt
@@ -23,7 +23,7 @@ fun MovieTile(
     movie: Movie,
     onClick: (movieId: Int, title: String) -> Unit
 ) {
-    val imageUrl = movie.poster_path ?: ""
+    val imageUrl = movie.posterPath ?: ""
 
     Card(
         modifier = Modifier.width(144.dp),

--- a/features/search/src/commonMain/kotlin/com/elna/moviedb/feature/search/ui/components/SearchResultItem.kt
+++ b/features/search/src/commonMain/kotlin/com/elna/moviedb/feature/search/ui/components/SearchResultItem.kt
@@ -45,7 +45,7 @@ fun SearchResultItem(
         ) {
             ImageLoader(
                 imageUrl = when (item) {
-                    is SearchResultItem.MovieItem -> item.movie.poster_path ?: ""
+                    is SearchResultItem.MovieItem -> item.movie.posterPath ?: ""
                     is SearchResultItem.TvShowItem -> item.tvShow.posterPath ?: ""
                     is SearchResultItem.PersonItem -> item.profilePath ?: ""
                 },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Movie details now include a Trailers section with horizontal cards, thumbnails, site badges, and tap-to-open playback.
  * Up to 10 relevant trailers shown, filtered and ordered for relevance.

* **Bug Fixes / Reliability**
  * Offline-first caching for movie details and trailers for faster loads and offline availability.
  * Trailer fetch failures no longer block loading of movie details; language changes trigger proper refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->