### PR TITLE
Add movie cast to movie details screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,3 +442,5 @@ This app was built with the assistance of **[Claude Code](https://claude.com/cla
 - [ ] Implement deep linking support
 - [ ] Add CI/CD pipeline with GitHub Actions
 - [ ] Add analytics and crash reporting
+
+![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/elnatand/https%3A%2F%2Fgithub.com%2Felnatand%2Fcmp-moviedb%2F)

--- a/core/data/src/commonMain/kotlin/com/elna/moviedb/core/data/tv_shows/TvShowRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/com/elna/moviedb/core/data/tv_shows/TvShowRepositoryImpl.kt
@@ -277,7 +277,6 @@ class TvShowRepositoryImpl(
                     .filter { it.type == "Trailer" || it.type == "Teaser" }
                     .sortedWith(compareByDescending<RemoteVideo> { it.official }
                         .thenByDescending { it.publishedAt })
-                    .take(10)
                     .map { it.toDomain() }
             }
 
@@ -289,7 +288,6 @@ class TvShowRepositoryImpl(
             is AppResult.Success -> {
                 creditsResult.data.cast
                     ?.sortedBy { it.order }
-                    ?.take(15)
                     ?.map { it.toDomain() }
                     ?: emptyList()
             }

--- a/core/database/schemas/com.elna.moviedb.core.database.AppDatabase/1.json
+++ b/core/database/schemas/com.elna.moviedb.core.database.AppDatabase/1.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "d9aedf7b71db155dc833389e6719bd94",
+    "identityHash": "08a6c11d55b6624abde63d44d8930c75",
     "entities": [
       {
         "tableName": "MovieEntity",
@@ -257,11 +257,94 @@
             ]
           }
         ]
+      },
+      {
+        "tableName": "cast_members",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`dbId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `movie_id` INTEGER NOT NULL, `person_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `character` TEXT NOT NULL, `profile_path` TEXT, `order` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "dbId",
+            "columnName": "dbId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "movieId",
+            "columnName": "movie_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "personId",
+            "columnName": "person_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "character",
+            "columnName": "character",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profilePath",
+            "columnName": "profile_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "dbId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cast_members_movie_id",
+            "unique": false,
+            "columnNames": [
+              "movie_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cast_members_movie_id` ON `${TABLE_NAME}` (`movie_id`)"
+          },
+          {
+            "name": "index_cast_members_person_id",
+            "unique": false,
+            "columnNames": [
+              "person_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cast_members_person_id` ON `${TABLE_NAME}` (`person_id`)"
+          },
+          {
+            "name": "index_cast_members_movie_id_person_id",
+            "unique": true,
+            "columnNames": [
+              "movie_id",
+              "person_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_cast_members_movie_id_person_id` ON `${TABLE_NAME}` (`movie_id`, `person_id`)"
+          }
+        ]
       }
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd9aedf7b71db155dc833389e6719bd94')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '08a6c11d55b6624abde63d44d8930c75')"
     ]
   }
 }

--- a/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/Database.kt
+++ b/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/Database.kt
@@ -6,6 +6,7 @@ import androidx.room.RoomDatabase
 import androidx.room.RoomDatabaseConstructor
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import com.elna.moviedb.core.common.AppDispatchers
+import com.elna.moviedb.core.database.model.CastMemberEntity
 import com.elna.moviedb.core.database.model.MovieDetailsEntity
 import com.elna.moviedb.core.database.model.MovieEntity
 import com.elna.moviedb.core.database.model.VideoEntity
@@ -15,7 +16,8 @@ import com.elna.moviedb.core.database.model.VideoEntity
     entities = [
         MovieEntity::class,
         MovieDetailsEntity::class,
-        VideoEntity::class
+        VideoEntity::class,
+        CastMemberEntity::class
     ],
     version = 1
 )

--- a/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/MovieDetailsDao.kt
+++ b/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/MovieDetailsDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import com.elna.moviedb.core.database.model.CastMemberEntity
 import com.elna.moviedb.core.database.model.MovieDetailsEntity
 import com.elna.moviedb.core.database.model.VideoEntity
 
@@ -26,4 +27,13 @@ interface MovieDetailsDao {
 
     @Query("DELETE FROM videos WHERE movie_id = :movieId")
     suspend fun deleteVideosForMovie(movieId: Int)
+
+    @Query("SELECT * FROM cast_members WHERE movie_id = :movieId ORDER BY `order` ASC")
+    suspend fun getCastForMovie(movieId: Int): List<CastMemberEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertCastMembers(cast: List<CastMemberEntity>)
+
+    @Query("DELETE FROM cast_members WHERE movie_id = :movieId")
+    suspend fun deleteCastForMovie(movieId: Int)
 }

--- a/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/MovieDetailsDao.kt
+++ b/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/MovieDetailsDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import com.elna.moviedb.core.database.model.CastMemberEntity
 import com.elna.moviedb.core.database.model.MovieDetailsEntity
 import com.elna.moviedb.core.database.model.VideoEntity
@@ -36,6 +37,13 @@ interface MovieDetailsDao {
 
     @Query("DELETE FROM cast_members WHERE movie_id = :movieId")
     suspend fun deleteCastForMovie(movieId: Int)
+
     @Query("DELETE FROM cast_members")
     suspend fun clearAllCast()
+
+    @Transaction
+    suspend fun replaceCastForMovie(movieId: Int, cast: List<CastMemberEntity>) {
+        deleteCastForMovie(movieId)
+        if (cast.isNotEmpty()) insertCastMembers(cast)
+    }
 }

--- a/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/MovieDetailsDao.kt
+++ b/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/MovieDetailsDao.kt
@@ -36,4 +36,6 @@ interface MovieDetailsDao {
 
     @Query("DELETE FROM cast_members WHERE movie_id = :movieId")
     suspend fun deleteCastForMovie(movieId: Int)
+    @Query("DELETE FROM cast_members")
+    suspend fun clearAllCast()
 }

--- a/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/MoviesLocalDataSource.kt
+++ b/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/MoviesLocalDataSource.kt
@@ -1,5 +1,6 @@
 package com.elna.moviedb.core.database
 
+import com.elna.moviedb.core.database.model.CastMemberEntity
 import com.elna.moviedb.core.database.model.MovieDetailsEntity
 import com.elna.moviedb.core.database.model.MovieEntity
 import com.elna.moviedb.core.database.model.VideoEntity
@@ -11,10 +12,6 @@ class MoviesLocalDataSource(
 ) {
     fun getMoviesByCategoryAsFlow(category: String): Flow<List<MovieEntity>> {
         return movieDao.getMoviesByCategoryAsFlow(category)
-    }
-
-    fun getAllMoviesAsFlow(): Flow<List<MovieEntity>> {
-        return movieDao.getAllMoviesAsFlow()
     }
 
     suspend fun insertMoviesPage(movies: List<MovieEntity>) {
@@ -29,10 +26,6 @@ class MoviesLocalDataSource(
 
     suspend fun insertMovieDetails(movieDetails: MovieDetailsEntity) {
         movieDetailsDao.insertMovieDetails(movieDetails)
-    }
-
-    suspend fun clearMoviesByCategory(category: String) {
-        movieDao.clearMoviesByCategory(category)
     }
 
     suspend fun clearAllMovies() {
@@ -50,5 +43,17 @@ class MoviesLocalDataSource(
 
     suspend fun deleteVideosForMovie(movieId: Int) {
         movieDetailsDao.deleteVideosForMovie(movieId)
+    }
+
+    suspend fun getCastForMovie(movieId: Int): List<CastMemberEntity> {
+        return movieDetailsDao.getCastForMovie(movieId)
+    }
+
+    suspend fun insertCastMembers(cast: List<CastMemberEntity>) {
+        movieDetailsDao.insertCastMembers(cast)
+    }
+
+    suspend fun deleteCastForMovie(movieId: Int) {
+        movieDetailsDao.deleteCastForMovie(movieId)
     }
 }

--- a/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/MoviesLocalDataSource.kt
+++ b/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/MoviesLocalDataSource.kt
@@ -1,5 +1,6 @@
 package com.elna.moviedb.core.database
 
+import androidx.room.Transaction
 import com.elna.moviedb.core.database.model.CastMemberEntity
 import com.elna.moviedb.core.database.model.MovieDetailsEntity
 import com.elna.moviedb.core.database.model.MovieEntity
@@ -31,6 +32,7 @@ class MoviesLocalDataSource(
     suspend fun clearAllMovies() {
         movieDao.clearAllMovies()
         movieDetailsDao.clearAllMovieDetails()
+        movieDetailsDao.clearAllCast()
     }
 
     suspend fun getVideosForMovie(movieId: Int): List<VideoEntity> {
@@ -55,5 +57,11 @@ class MoviesLocalDataSource(
 
     suspend fun deleteCastForMovie(movieId: Int) {
         movieDetailsDao.deleteCastForMovie(movieId)
+    }
+
+    @Transaction
+    suspend fun replaceCastForMovie(movieId: Int, cast: List<CastMemberEntity>) {
+        deleteCastForMovie(movieId)
+        if (cast.isNotEmpty()) insertCastMembers(cast)
     }
 }

--- a/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/MoviesLocalDataSource.kt
+++ b/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/MoviesLocalDataSource.kt
@@ -1,6 +1,5 @@
 package com.elna.moviedb.core.database
 
-import androidx.room.Transaction
 import com.elna.moviedb.core.database.model.CastMemberEntity
 import com.elna.moviedb.core.database.model.MovieDetailsEntity
 import com.elna.moviedb.core.database.model.MovieEntity
@@ -59,9 +58,7 @@ class MoviesLocalDataSource(
         movieDetailsDao.deleteCastForMovie(movieId)
     }
 
-    @Transaction
     suspend fun replaceCastForMovie(movieId: Int, cast: List<CastMemberEntity>) {
-        deleteCastForMovie(movieId)
-        if (cast.isNotEmpty()) insertCastMembers(cast)
+        movieDetailsDao.replaceCastForMovie(movieId, cast)
     }
 }

--- a/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/model/CastMemberEntity.kt
+++ b/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/model/CastMemberEntity.kt
@@ -2,10 +2,17 @@ package com.elna.moviedb.core.database.model
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.elna.moviedb.core.model.CastMember
 
-@Entity(tableName = "cast_members")
+@Entity(
+    tableName = "cast_members", indices = [
+        Index(value = ["movie_id"]),
+        Index(value = ["person_id"]),
+        Index(value = ["movie_id", "person_id"], unique = true)
+    ]
+)
 data class CastMemberEntity(
     @PrimaryKey(autoGenerate = true)
     val dbId: Int = 0,

--- a/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/model/CastMemberEntity.kt
+++ b/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/model/CastMemberEntity.kt
@@ -1,0 +1,29 @@
+package com.elna.moviedb.core.database.model
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.elna.moviedb.core.model.CastMember
+
+@Entity(tableName = "cast_members")
+data class CastMemberEntity(
+    @PrimaryKey(autoGenerate = true)
+    val dbId: Int = 0,
+    @ColumnInfo(name = "movie_id")
+    val movieId: Int,
+    @ColumnInfo(name = "person_id")
+    val personId: Int,
+    val name: String,
+    val character: String,
+    @ColumnInfo(name = "profile_path")
+    val profilePath: String?,
+    val order: Int
+) {
+    fun toDomain() = CastMember(
+        id = personId,
+        name = name,
+        character = character,
+        profilePath = profilePath,
+        order = order
+    )
+}

--- a/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/model/CastMemberEntity.kt
+++ b/core/database/src/commonMain/kotlin/com/elna/moviedb/core/database/model/CastMemberEntity.kt
@@ -2,6 +2,7 @@ package com.elna.moviedb.core.database.model
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
+import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.elna.moviedb.core.model.CastMember
@@ -11,6 +12,15 @@ import com.elna.moviedb.core.model.CastMember
         Index(value = ["movie_id"]),
         Index(value = ["person_id"]),
         Index(value = ["movie_id", "person_id"], unique = true)
+    ], foreignKeys = [
+        ForeignKey(
+            entity = MovieDetailsEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["movie_id"],
+            onDelete = ForeignKey.CASCADE,
+            onUpdate = ForeignKey.NO_ACTION,
+            deferred = true
+        )
     ]
 )
 data class CastMemberEntity(

--- a/core/model/src/commonMain/kotlin/com/elna/moviedb/core/model/MovieDetails.kt
+++ b/core/model/src/commonMain/kotlin/com/elna/moviedb/core/model/MovieDetails.kt
@@ -30,5 +30,6 @@ data class MovieDetails(
     val productionCompanies: List<String>?,
     val productionCountries: List<String>?,
     val spokenLanguages: List<String>?,
-    val trailers: List<Video>? = null
+    val trailers: List<Video>? = null,
+    val cast: List<CastMember>? = null
 )

--- a/core/network/src/commonMain/kotlin/com/elna/moviedb/core/network/MoviesRemoteDataSource.kt
+++ b/core/network/src/commonMain/kotlin/com/elna/moviedb/core/network/MoviesRemoteDataSource.kt
@@ -4,6 +4,7 @@ import com.elna.moviedb.core.common.AppDispatchers
 import com.elna.moviedb.core.model.AppResult
 import com.elna.moviedb.core.network.model.TMDB_API_KEY
 import com.elna.moviedb.core.network.model.TMDB_BASE_URL
+import com.elna.moviedb.core.network.model.movies.RemoteMovieCredits
 import com.elna.moviedb.core.network.model.movies.RemoteMovieDetails
 import com.elna.moviedb.core.network.model.movies.RemoteMoviesPage
 import com.elna.moviedb.core.network.model.videos.RemoteVideoResponse
@@ -51,6 +52,19 @@ class MoviesRemoteDataSource(
                         parameters.append("include_video_language", "$language,null")
                     }
                 }.body<RemoteVideoResponse>()
+            }
+        }
+    }
+
+    suspend fun getMovieCredits(movieId: Int, language: String): AppResult<RemoteMovieCredits> {
+        return withContext(appDispatchers.io) {
+            safeApiCall {
+                httpClient.get("${TMDB_BASE_URL}movie/${movieId}/credits") {
+                    url {
+                        parameters.append("api_key", TMDB_API_KEY)
+                        parameters.append("language", language)
+                    }
+                }.body<RemoteMovieCredits>()
             }
         }
     }

--- a/core/network/src/commonMain/kotlin/com/elna/moviedb/core/network/model/movies/RemoteMovieCredits.kt
+++ b/core/network/src/commonMain/kotlin/com/elna/moviedb/core/network/model/movies/RemoteMovieCredits.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class RemoteMovieCredits(
     @SerialName("id")
-    val id: Int?,
+    val id: Int,
     @SerialName("cast")
     val cast: List<RemoteCastMember>?
 )

--- a/core/network/src/commonMain/kotlin/com/elna/moviedb/core/network/model/movies/RemoteMovieCredits.kt
+++ b/core/network/src/commonMain/kotlin/com/elna/moviedb/core/network/model/movies/RemoteMovieCredits.kt
@@ -1,0 +1,48 @@
+package com.elna.moviedb.core.network.model.movies
+
+import com.elna.moviedb.core.model.CastMember
+import com.elna.moviedb.core.network.model.TMDB_IMAGE_URL
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RemoteMovieCredits(
+    @SerialName("id")
+    val id: Int?,
+    @SerialName("cast")
+    val cast: List<RemoteCastMember>?
+)
+
+@Serializable
+data class RemoteCastMember(
+    @SerialName("adult")
+    val adult: Boolean?,
+    @SerialName("gender")
+    val gender: Int?,
+    @SerialName("id")
+    val id: Int,
+    @SerialName("known_for_department")
+    val knownForDepartment: String?,
+    @SerialName("name")
+    val name: String,
+    @SerialName("original_name")
+    val originalName: String?,
+    @SerialName("popularity")
+    val popularity: Double?,
+    @SerialName("profile_path")
+    val profilePath: String?,
+    @SerialName("character")
+    val character: String,
+    @SerialName("credit_id")
+    val creditId: String?,
+    @SerialName("order")
+    val order: Int
+)
+
+fun RemoteCastMember.toDomain() = CastMember(
+    id = id,
+    name = name,
+    character = character,
+    profilePath = profilePath?.let { "$TMDB_IMAGE_URL$it" },
+    order = order
+)

--- a/features/movies/src/commonMain/kotlin/com/elna/moviedb/feature/movies/navigation/MoviesNavigation.kt
+++ b/features/movies/src/commonMain/kotlin/com/elna/moviedb/feature/movies/navigation/MoviesNavigation.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.elna.moviedb.core.ui.navigation.MovieDetailsRoute
 import com.elna.moviedb.core.ui.navigation.MoviesRoute
+import com.elna.moviedb.core.ui.navigation.PersonDetailsRoute
 import com.elna.moviedb.feature.movies.ui.movie_details.MovieDetailsScreen
 import com.elna.moviedb.feature.movies.ui.movies.MoviesScreen
 
@@ -35,6 +36,9 @@ fun NavGraphBuilder.movieDetailsScene(navigator: NavHostController) {
 
         MovieDetailsScreen(
             movieId = movieId,
+            onCastMemberClick = { personId ->
+                navigator.navigate(PersonDetailsRoute(personId))
+            }
         )
     }
 }

--- a/features/movies/src/commonMain/kotlin/com/elna/moviedb/feature/movies/ui/components/CastMemberCard.kt
+++ b/features/movies/src/commonMain/kotlin/com/elna/moviedb/feature/movies/ui/components/CastMemberCard.kt
@@ -1,0 +1,92 @@
+package com.elna.moviedb.feature.movies.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.elna.moviedb.core.model.CastMember
+import com.elna.moviedb.core.ui.utils.ImageLoader
+
+@Composable
+internal fun CastMemberCard(
+    castMember: CastMember,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .width(110.dp)
+            .padding(2.dp),
+        onClick = onClick,
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column {
+            // Profile Image
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(160.dp)
+            ) {
+                castMember.profilePath?.let { profilePath ->
+                    ImageLoader(
+                        imageUrl = profilePath,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                } ?: Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Person,
+                        contentDescription = null,
+                        modifier = Modifier.size(48.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            // Cast Info
+            Column(
+                modifier = Modifier
+                    .height(72.dp)
+                    .padding(8.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    text = castMember.name,
+                    maxLines = 2,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = castMember.character,
+                    maxLines = 2,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+    }
+}

--- a/features/movies/src/commonMain/kotlin/com/elna/moviedb/feature/movies/ui/components/CastSection.kt
+++ b/features/movies/src/commonMain/kotlin/com/elna/moviedb/feature/movies/ui/components/CastSection.kt
@@ -1,0 +1,58 @@
+package com.elna.moviedb.feature.movies.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.elna.moviedb.core.model.MovieDetails
+import com.elna.moviedb.resources.Res
+import com.elna.moviedb.resources.cast
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun CastSection(
+    movie: MovieDetails,
+    onCastMemberClick: (Int) -> Unit
+) {
+    movie.cast?.takeIf { it.isNotEmpty() }?.let { cast ->
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text(
+                    text = stringResource(Res.string.cast),
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold
+                )
+
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    items(
+                        items = cast,
+                        key = { it.id }
+                    ) { castMember ->
+                        CastMemberCard(
+                            castMember = castMember,
+                            onClick = { onCastMemberClick(castMember.id) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/features/movies/src/commonMain/kotlin/com/elna/moviedb/feature/movies/ui/movie_details/MovieDetailsScreen.kt
+++ b/features/movies/src/commonMain/kotlin/com/elna/moviedb/feature/movies/ui/movie_details/MovieDetailsScreen.kt
@@ -27,7 +27,9 @@ import androidx.compose.ui.unit.dp
 import com.elna.moviedb.core.model.MovieDetails
 import com.elna.moviedb.core.ui.design_system.AppErrorComponent
 import com.elna.moviedb.core.ui.design_system.AppLoader
+import com.elna.moviedb.feature.movies.model.MovieDetailsEvent
 import com.elna.moviedb.feature.movies.ui.components.BoxOfficeItem
+import com.elna.moviedb.feature.movies.ui.components.CastSection
 import com.elna.moviedb.feature.movies.ui.components.InfoItem
 import com.elna.moviedb.feature.movies.ui.components.MovieHeroSection
 import com.elna.moviedb.feature.movies.ui.components.SectionCard
@@ -52,13 +54,15 @@ import org.koin.core.parameter.parametersOf
 @Composable
 fun MovieDetailsScreen(
     movieId: Int,
+    onCastMemberClick: (Int) -> Unit = {}
 ) {
     val viewModel = koinViewModel<MovieDetailsViewModel> { parametersOf(movieId) }
     val uiState by viewModel.uiState.collectAsState()
 
     MovieDetailsScreen(
         uiState = uiState,
-        onRetry = { viewModel.onEvent(com.elna.moviedb.feature.movies.model.MovieDetailsEvent.Retry) }
+        onRetry = { viewModel.onEvent(MovieDetailsEvent.Retry) },
+        onCastMemberClick = onCastMemberClick
     )
 }
 
@@ -66,7 +70,8 @@ fun MovieDetailsScreen(
 @Composable
 private fun MovieDetailsScreen(
     uiState: MovieDetailsViewModel.MovieDetailsUiState,
-    onRetry: () -> Unit
+    onRetry: () -> Unit,
+    onCastMemberClick: (Int) -> Unit = {}
 ) {
     Box(
         contentAlignment = Alignment.Center,
@@ -80,7 +85,10 @@ private fun MovieDetailsScreen(
             )
 
             is MovieDetailsViewModel.MovieDetailsUiState.Success -> {
-                MovieDetailsContent(movie = uiState.movieDetails)
+                MovieDetailsContent(
+                    movie = uiState.movieDetails,
+                    onCastMemberClick = onCastMemberClick
+                )
             }
         }
     }
@@ -88,7 +96,10 @@ private fun MovieDetailsScreen(
 
 
 @Composable
-private fun MovieDetailsContent(movie: MovieDetails) {
+private fun MovieDetailsContent(
+    movie: MovieDetails,
+    onCastMemberClick: (Int) -> Unit = {}
+) {
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -150,6 +161,12 @@ private fun MovieDetailsContent(movie: MovieDetails) {
             movie.trailers?.takeIf { it.isNotEmpty() }?.let { trailers ->
                 TrailersSection(trailers = trailers)
             }
+
+            // Cast Section
+            CastSection(
+                movie = movie,
+                onCastMemberClick = onCastMemberClick
+            )
 
             // Genres Section
             movie.genres?.takeIf { it.isNotEmpty() }?.let { genres ->


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Movie details now show cast members with images, names and character info in a horizontal scroll; tapping a cast member opens their profile.
  * Cast and trailers are fetched in parallel and returned together for faster details.
  * TV show and movie details now surface full lists of trailers and cast instead of truncated previews.
* **Chores**
  * Cast data is cached locally for offline access and refreshed seamlessly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->