### PR TITLE
refactor: Simplify navigation by removing nested flows

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/elna/moviedb/AppState.kt
+++ b/composeApp/src/commonMain/kotlin/com/elna/moviedb/AppState.kt
@@ -14,7 +14,7 @@ import com.elna.moviedb.navigation.TopLevelDestination
 
 @Composable
 fun rememberAppState(
-    navBackStack: SnapshotStateList<Route> = remember { mutableStateListOf(MoviesRoute()) }
+    navBackStack: SnapshotStateList<Route> = remember { mutableStateListOf(MoviesRoute.MoviesListRoute) }
 ): AppState {
     return remember(navBackStack) {
         AppState(navBackStack = navBackStack)
@@ -42,8 +42,8 @@ class AppState(
 
     fun navigateToTopLevelDestination(topLevelDestination: TopLevelDestination) {
         when (topLevelDestination) {
-            TopLevelDestination.MOVIES -> navBackStack.add(MoviesRoute())
-            TopLevelDestination.TV_SHOWS -> navBackStack.add(TvShowsRoute())
+            TopLevelDestination.MOVIES -> navBackStack.add(MoviesRoute.MoviesListRoute)
+            TopLevelDestination.TV_SHOWS -> navBackStack.add(TvShowsRoute.TvShowsListRoute)
             TopLevelDestination.SEARCH -> navBackStack.add(SearchRoute)
             TopLevelDestination.PROFILE -> navBackStack.add(ProfileRoute)
         }

--- a/composeApp/src/commonMain/kotlin/com/elna/moviedb/navigation/TopLevelDestination.kt
+++ b/composeApp/src/commonMain/kotlin/com/elna/moviedb/navigation/TopLevelDestination.kt
@@ -18,11 +18,11 @@ enum class TopLevelDestination(
 ) {
     MOVIES(
         icon = Icons.Filled.Theaters,
-        route = MoviesRoute()
+        route = MoviesRoute.MoviesListRoute
     ),
     TV_SHOWS(
         icon = Icons.Filled.Tv,
-        route = TvShowsRoute()
+        route = TvShowsRoute.TvShowsListRoute
     ),
     SEARCH(
         icon = Icons.Filled.Search,

--- a/core/ui/src/commonMain/kotlin/com/elna/moviedb/core/ui/navigation/Routes.kt
+++ b/core/ui/src/commonMain/kotlin/com/elna/moviedb/core/ui/navigation/Routes.kt
@@ -6,7 +6,7 @@ sealed interface Route
 
 
 @Serializable
-data class MoviesRoute(val startAt: Route = MoviesListRoute) : Route {
+data object MoviesRoute : Route {
 
     @Serializable
     data object MoviesListRoute : Route
@@ -18,7 +18,7 @@ data class MoviesRoute(val startAt: Route = MoviesListRoute) : Route {
 }
 
 @Serializable
-data class TvShowsRoute(val startAt: Route = TvShowsListRoute) : Route {
+data object TvShowsRoute : Route {
 
     @Serializable
     data object TvShowsListRoute : Route

--- a/features/movies/src/commonMain/kotlin/com/elna/moviedb/feature/movies/navigation/MoviesNavigation.kt
+++ b/features/movies/src/commonMain/kotlin/com/elna/moviedb/feature/movies/navigation/MoviesNavigation.kt
@@ -19,46 +19,19 @@ import com.elna.moviedb.feature.movies.ui.movies.MoviesScreen
 fun EntryProviderScope<Route>.moviesFlow(
     rootBackStack: SnapshotStateList<Route>
 ) {
-    entry<MoviesRoute> {
-        MoviesNavigation(
-            rootBackStack = rootBackStack,
-            startDestination = it.startAt,
+
+    entry<MoviesRoute.MoviesListRoute> {
+        MoviesScreen(onClick = { movieId, _ ->
+            rootBackStack.add(MoviesRoute.MovieDetailsRoute(movieId))
+        })
+    }
+
+    entry<MoviesRoute.MovieDetailsRoute> {
+        MovieDetailsScreen(
+            movieId = it.movieId,
+            onCastMemberClick = { personId ->
+                rootBackStack.add(PersonDetailsRoute(personId))
+            }
         )
     }
-}
-
-
-@Composable
-private fun MoviesNavigation(
-    rootBackStack: SnapshotStateList<Route>,
-    startDestination: Route,
-) {
-    val backStack: SnapshotStateList<Route> = remember { mutableStateListOf(startDestination) }
-
-    NavDisplay(
-        backStack = backStack,
-        entryDecorators = listOf(
-            rememberSaveableStateHolderNavEntryDecorator(),
-            rememberViewModelStoreNavEntryDecorator()
-        ),
-        entryProvider = entryProvider {
-            entry<MoviesRoute.MoviesListRoute> {
-                MoviesScreen(onClick = { movieId, _ ->
-                    backStack.add(MoviesRoute.MovieDetailsRoute(movieId))
-                })
-            }
-            entry<MoviesRoute.MovieDetailsRoute> {
-                MovieDetailsScreen(
-                    movieId = it.movieId,
-                    onCastMemberClick = { personId ->
-                        val movieDetailsRoute = MoviesRoute(startAt = it)
-                        if (movieDetailsRoute !in rootBackStack) {
-                            rootBackStack.add(movieDetailsRoute)
-                        }
-                        rootBackStack.add(PersonDetailsRoute(personId))
-                    }
-                )
-            }
-        }
-    )
 }

--- a/features/person/src/commonMain/kotlin/com/elna/moviedb/feature/person/navigation/PersonNavigation.kt
+++ b/features/person/src/commonMain/kotlin/com/elna/moviedb/feature/person/navigation/PersonNavigation.kt
@@ -17,13 +17,8 @@ fun EntryProviderScope<Route>.personDetailsEntry(
             personId = it.personId,
             onCreditClick = { id, mediaType ->
                 when (mediaType) {
-                    MediaType.MOVIE -> rootBackStack.add(
-                        MoviesRoute(startAt = MoviesRoute.MovieDetailsRoute(id))
-                    )
-
-                    MediaType.TV -> rootBackStack.add(
-                        TvShowsRoute(startAt = TvShowsRoute.TvShowDetailsRoute(id))
-                    )
+                    MediaType.MOVIE -> rootBackStack.add(MoviesRoute.MovieDetailsRoute(id))
+                    MediaType.TV -> rootBackStack.add(TvShowsRoute.TvShowDetailsRoute(id))
                 }
             }
         )

--- a/features/search/src/commonMain/kotlin/com/elna/moviedb/feature/search/navigation/SearchNavigation.kt
+++ b/features/search/src/commonMain/kotlin/com/elna/moviedb/feature/search/navigation/SearchNavigation.kt
@@ -15,14 +15,10 @@ fun EntryProviderScope<Route>.searchEntry(
     entry<SearchRoute> {
         SearchScreen(
             onMovieClicked = { movieId ->
-                rootBackStack.add(
-                    MoviesRoute(startAt = MoviesRoute.MovieDetailsRoute(movieId))
-                )
+                rootBackStack.add(MoviesRoute.MovieDetailsRoute(movieId))
             },
             onTvShowClicked = { tvShowId ->
-                rootBackStack.add(
-                    TvShowsRoute(startAt = TvShowsRoute.TvShowDetailsRoute(tvShowId))
-                )
+                rootBackStack.add(TvShowsRoute.TvShowDetailsRoute(tvShowId))
             },
             onPersonClicked = { personId ->
                 rootBackStack.add(PersonDetailsRoute(personId))

--- a/features/tv-shows/src/commonMain/kotlin/com/elna/moviedb/feature/tvshows/navigation/TvShowsNavigation.kt
+++ b/features/tv-shows/src/commonMain/kotlin/com/elna/moviedb/feature/tvshows/navigation/TvShowsNavigation.kt
@@ -18,10 +18,18 @@ import com.elna.moviedb.feature.tvshows.ui.tv_shows.TvShowsScreen
 fun EntryProviderScope<Route>.tvShowsFlow(
     rootBackStack: SnapshotStateList<Route>
 ) {
-    entry<TvShowsRoute> {
-        TvShowsNavigation(
-            rootBackStack = rootBackStack,
-            startDestination = it.startAt
+    entry<TvShowsRoute.TvShowsListRoute> {
+        TvShowsScreen(onClick = { tvShowId, _ ->
+            rootBackStack.add(TvShowsRoute.TvShowDetailsRoute(tvShowId))
+        })
+    }
+
+    entry<TvShowsRoute.TvShowDetailsRoute> {
+        TvShowDetailsScreen(
+            tvShowId = it.tvShowId,
+            onCastMemberClick = { personId ->
+                rootBackStack.add(PersonDetailsRoute(personId))
+            }
         )
     }
 }
@@ -40,23 +48,7 @@ private fun TvShowsNavigation(
             rememberViewModelStoreNavEntryDecorator()
         ),
         entryProvider = entryProvider {
-            entry<TvShowsRoute.TvShowsListRoute> {
-                TvShowsScreen(onClick = { tvShowId, _ ->
-                    backStack.add(TvShowsRoute.TvShowDetailsRoute(tvShowId))
-                })
-            }
-            entry<TvShowsRoute.TvShowDetailsRoute> {
-                TvShowDetailsScreen(
-                    tvShowId = it.tvShowId,
-                    onCastMemberClick = { personId ->
-                        val tvShowDetailsRoute = TvShowsRoute(startAt = it)
-                        if (tvShowDetailsRoute !in rootBackStack) {
-                            rootBackStack.add(tvShowDetailsRoute)
-                        }
-                        rootBackStack.add(PersonDetailsRoute(personId))
-                    }
-                )
-            }
+
         }
     )
 }


### PR DESCRIPTION
This commit refactors the navigation logic by removing nested navigation flows for the Movies and TV Shows features.

Key changes include:
- `MoviesRoute` and `TvShowsRoute` are now `data object`s instead of `data class`es, as they no longer need to hold a `startAt` parameter.
- The nested `MoviesNavigation` and `TvShowsNavigation` Composables have been eliminated, and their routes are now registered directly in the root graph.
- Navigation from Search and Person details now directly pushes the specific `MovieDetailsRoute` or `TvShowDetailsRoute` to the root back stack, simplifying the navigation graph.
- The initial route in `AppState` and the routes in `TopLevelDestination` have been updated to use the direct list routes (e.g., `MoviesRoute.MoviesListRoute`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor

* Refined navigation architecture to streamline transitions between movies, TV shows, and detail screens.
* Improved consistency in how the application handles navigation between primary sections and nested detail views.
* Simplified the flow when accessing movie details, TV show details, and cast member information from various screens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->