### PR TITLE
refactor(common): Use expect/actual for AppDispatchers

### DIFF
--- a/core/common/src/androidMain/kotlin/com/elna/moviedb/core/common/AppDispatchers.android.kt
+++ b/core/common/src/androidMain/kotlin/com/elna/moviedb/core/common/AppDispatchers.android.kt
@@ -1,0 +1,11 @@
+package com.elna.moviedb.core.common
+
+import kotlinx.coroutines.Dispatchers
+
+class AndroidDispatcherProvider : AppDispatchers {
+    override val io = Dispatchers.IO
+    override val main = Dispatchers.Main
+    override val default = Dispatchers.Default
+}
+
+actual fun provideAppDispatchers(): AppDispatchers = AndroidDispatcherProvider()

--- a/core/common/src/androidMain/kotlin/com/elna/moviedb/core/common/AppDispatchers.android.kt
+++ b/core/common/src/androidMain/kotlin/com/elna/moviedb/core/common/AppDispatchers.android.kt
@@ -2,10 +2,10 @@ package com.elna.moviedb.core.common
 
 import kotlinx.coroutines.Dispatchers
 
-class AndroidDispatcherProvider : AppDispatchers {
+object AndroidDispatcherProvider : AppDispatchers {
     override val io = Dispatchers.IO
     override val main = Dispatchers.Main
     override val default = Dispatchers.Default
 }
 
-actual fun provideAppDispatchers(): AppDispatchers = AndroidDispatcherProvider()
+actual fun provideAppDispatchers(): AppDispatchers = AndroidDispatcherProvider

--- a/core/common/src/commonMain/kotlin/com/elna/moviedb/core/common/AppDispatchers.kt
+++ b/core/common/src/commonMain/kotlin/com/elna/moviedb/core/common/AppDispatchers.kt
@@ -1,35 +1,14 @@
 package com.elna.moviedb.core.common
 
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 
 /**
  * Provides coroutine dispatchers for different execution contexts.
- *
- * This sealed interface allows for dependency injection while providing
- * a default implementation via companion object for production use.
- * Tests can provide custom implementations for controllable test dispatchers.
- *
- * Usage:
- * ```
- * class MyRepository(private val appDispatchers: AppDispatchers) {
- *     private val scope = CoroutineScope(appDispatchers.Main)
- *
- *     suspend fun doWork() {
- *         withContext(appDispatchers.IO) { /* IO work */ }
- *     }
- * }
- * ```
  */
-sealed interface AppDispatchers {
+interface AppDispatchers {
     val io: CoroutineDispatcher
     val main: CoroutineDispatcher
     val default: CoroutineDispatcher
-
-    companion object : AppDispatchers {
-        override val io: CoroutineDispatcher = Dispatchers.IO
-        override val main: CoroutineDispatcher = Dispatchers.Main
-        override val default: CoroutineDispatcher = Dispatchers.Default
-    }
 }
+
+expect fun provideAppDispatchers(): AppDispatchers

--- a/core/common/src/commonMain/kotlin/com/elna/moviedb/core/common/di/CommonModule.kt
+++ b/core/common/src/commonMain/kotlin/com/elna/moviedb/core/common/di/CommonModule.kt
@@ -1,11 +1,12 @@
 package com.elna.moviedb.core.common.di
 
 import com.elna.moviedb.core.common.AppDispatchers
+import com.elna.moviedb.core.common.provideAppDispatchers
 import com.elna.moviedb.core.common.utils.AppVersion
 import com.elna.moviedb.core.common.utils.AppVersionImpl
 import org.koin.dsl.module
 
 val commonModule = module {
-    single<AppDispatchers> { AppDispatchers }
+    single<AppDispatchers> { provideAppDispatchers() }
     single<AppVersion> { AppVersionImpl() }
 }

--- a/core/common/src/iosMain/kotlin/com/elna/moviedb/core/common/AppDispatchers.ios.kt
+++ b/core/common/src/iosMain/kotlin/com/elna/moviedb/core/common/AppDispatchers.ios.kt
@@ -1,0 +1,11 @@
+package com.elna.moviedb.core.common
+
+import kotlinx.coroutines.Dispatchers
+
+class IOSDispatcherProvider : AppDispatchers {
+    override val io = Dispatchers.Default  // iOS doesnt have an dedicated io
+    override val main = Dispatchers.Main
+    override val default = Dispatchers.Default
+}
+
+actual fun provideAppDispatchers(): AppDispatchers = IOSDispatcherProvider()

--- a/core/common/src/iosMain/kotlin/com/elna/moviedb/core/common/AppDispatchers.ios.kt
+++ b/core/common/src/iosMain/kotlin/com/elna/moviedb/core/common/AppDispatchers.ios.kt
@@ -1,11 +1,12 @@
 package com.elna.moviedb.core.common
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 
-class IOSDispatcherProvider : AppDispatchers {
-    override val io = Dispatchers.Default  // iOS doesnt have an dedicated io
+object IOSDispatcherProvider : AppDispatchers {
+    override val io = Dispatchers.IO
     override val main = Dispatchers.Main
     override val default = Dispatchers.Default
 }
 
-actual fun provideAppDispatchers(): AppDispatchers = IOSDispatcherProvider()
+actual fun provideAppDispatchers(): AppDispatchers = IOSDispatcherProvider


### PR DESCRIPTION
This commit refactors the core-common module to provide AppDispatchers using the expect/actual pattern instead of a concrete implementation in commonMain. An expect function provideAppDispatchers() has been introduced in the common source set. Platform-specific actual implementations now provide the appropriate main and default dispatchers for each target.

This change leverages the Kotlin Multiplatform toolchain to handle platform-specifics, simplifying dependency injection and improving code organization. The Koin module remains clean and continues to provide AppDispatchers as a singleton throughout the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked dispatcher architecture to use a platform-specific provider pattern for Android and iOS.
  * Replaced prior sealed design with an interface-based approach and a factory-style provider.
  * Updated dependency injection to supply platform dispatchers, improving maintainability and cross-platform concurrency/resource handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->