### PR TITLE
Workaround for issues #33

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -1,17 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
         android:name=".MovieDBApp"
         android:allowBackup="true"
+        android:enableOnBackInvokedCallback="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.AppCompat.Light.NoActionBar"
-        android:usesCleartextTraffic="true">
+        android:usesCleartextTraffic="true"
+        tools:targetApi="33">
         <activity
             android:name=".MainActivity"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode"


### PR DESCRIPTION
This commit introduces a temporary workaround to resolve a visual glitch that occurs when using the predictive back gesture during a shared element transition. The Problem: On Android 13+, the predictive back gesture animation conflicts with the shared element transition animation, resulting in a broken or "mixed" visual effect.

The Solution (Workaround): To ensure a smooth and correct user experience during transitions, the predictive back gesture has been temporarily disabled for the MainActivity. This forces the system to fall back to the classic back navigation animation, which does not conflict with our shared element transitions.

Trade-Off: This is not a perfect solution. Users on newer Android versions will not see the modern predictive back gesture animation within the app.

Next Steps: This is considered a temporary measure. We should monitor updates to the underlying libraries (Jetpack Navigation, Material Components) for a proper fix that allows both features to coexist. This workaround should be removed once a permanent solution is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android manifest configuration for improved compatibility with Android 13+.
  * Modified back gesture callback handling for better app stability.
  * Configured API level targeting for consistent build behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->