### PR TITLE
Top-level destinations (bottom bar tabs) must not be stacked.

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/elna/moviedb/AppState.kt
+++ b/composeApp/src/commonMain/kotlin/com/elna/moviedb/AppState.kt
@@ -41,11 +41,16 @@ class AppState(
     }
 
     fun navigateToTopLevelDestination(topLevelDestination: TopLevelDestination) {
-        when (topLevelDestination) {
-            TopLevelDestination.MOVIES -> navBackStack.add(MoviesRoute.MoviesListRoute)
-            TopLevelDestination.TV_SHOWS -> navBackStack.add(TvShowsRoute.TvShowsListRoute)
-            TopLevelDestination.SEARCH -> navBackStack.add(SearchRoute)
-            TopLevelDestination.PROFILE -> navBackStack.add(ProfileRoute)
+        val targetRoute = when (topLevelDestination) {
+            TopLevelDestination.MOVIES -> MoviesRoute.MoviesListRoute
+            TopLevelDestination.TV_SHOWS -> TvShowsRoute.TvShowsListRoute
+            TopLevelDestination.SEARCH -> SearchRoute
+            TopLevelDestination.PROFILE -> ProfileRoute
         }
+
+        if (navBackStack.lastOrNull() == targetRoute) return
+
+        navBackStack.clear()
+        navBackStack.add(targetRoute)
     }
 }


### PR DESCRIPTION
code should behave like the popUpTo(startDestination) and clear everything above the root
Fix for  issues #35 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved navigation behavior for top-level destinations. Navigation now handles back stack management more efficiently, preventing redundant transitions and ensuring predictable navigation flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->