### PR TITLE
fix: Enhance stability, security, and localization consistency

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/elna/moviedb/AppState.kt
+++ b/composeApp/src/commonMain/kotlin/com/elna/moviedb/AppState.kt
@@ -30,14 +30,15 @@ class AppState(
 
     val currentTopLevelDestination: TopLevelDestination?
         @Composable get() {
+            val currentRoute = navBackStack.lastOrNull() ?: return null
             return TopLevelDestination.entries.firstOrNull { topLevelDestination ->
-                navBackStack.last() == topLevelDestination.route
+                currentRoute == topLevelDestination.route
             }
         }
 
     @Composable
     fun shouldShowBottomBar(): Boolean {
-        return navBackStack.last() in bottomBarRoutes
+        return navBackStack.lastOrNull() in bottomBarRoutes
     }
 
     fun navigateToTopLevelDestination(topLevelDestination: TopLevelDestination) {

--- a/core/data/src/commonMain/kotlin/com/elna/moviedb/core/data/LanguageChangeCoordinator.kt
+++ b/core/data/src/commonMain/kotlin/com/elna/moviedb/core/data/LanguageChangeCoordinator.kt
@@ -49,6 +49,11 @@ class LanguageChangeCoordinator(
     private val appSettingsPreferences: AppSettingsPreferences,
     appDispatchers: AppDispatchers,
 ) {
+    // All access to `listeners` is confined to `scope` (a single-threaded main
+    // dispatcher), so registration and iteration never run concurrently. This avoids
+    // a ConcurrentModificationException when a repository self-registers (possibly off
+    // the main thread, during lazy DI construction) while a language change is being
+    // dispatched to existing listeners.
     private val listeners = mutableSetOf<LanguageChangeListener>()
     private val scope = CoroutineScope(SupervisorJob() + appDispatchers.main)
 
@@ -70,8 +75,13 @@ class LanguageChangeCoordinator(
     /**
      * Registers a listener to be notified of language changes.
      * Listeners are typically repositories that need to clear/reload data.
+     *
+     * Registration is marshalled onto the coordinator's main-confined scope so it
+     * never races with in-flight notification dispatch.
      */
     fun registerListener(listener: LanguageChangeListener) {
-        listeners.add(listener)
+        scope.launch {
+            listeners.add(listener)
+        }
     }
 }

--- a/core/data/src/commonMain/kotlin/com/elna/moviedb/core/data/di/DataModule.kt
+++ b/core/data/src/commonMain/kotlin/com/elna/moviedb/core/data/di/DataModule.kt
@@ -21,17 +21,20 @@ val dataModule = module {
 
     single { LanguageProvider(get()) }
 
-    // Language change coordinator - uses Observer Pattern for loose coupling
-    // Lazily created when first repository is initialized
-    // Repositories self-register during their initialization
-    single {
+    // Language change coordinator - uses Observer Pattern for loose coupling.
+    // Created at startup so it begins observing language changes immediately,
+    // independent of which repository (if any) is injected first.
+    single(createdAtStart = true) {
         LanguageChangeCoordinator(
             appSettingsPreferences = get(),
             appDispatchers = get(),
         )
     }
 
-    single<MoviesRepository> {
+    // Created at startup so the repository self-registers as a language-change
+    // listener immediately. Otherwise a listener would only be wired up after the
+    // user first navigates to its screen, silently missing earlier language changes.
+    single<MoviesRepository>(createdAtStart = true) {
         MoviesRepositoryImpl(
             remoteDataSource = get(),
             localDataSource = get(),
@@ -42,7 +45,7 @@ val dataModule = module {
         )
     }
 
-    single<TvShowsRepository> {
+    single<TvShowsRepository>(createdAtStart = true) {
         TvShowRepositoryImpl(
             remoteDataSource = get(),
             languageProvider = get(),

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -60,5 +60,16 @@ buildkonfig {
             "TMDB_API_KEY",
             tmdbApiKey
         )
+
+        // Network request/response logging. OFF by default so release builds never
+        // log the request URL, which carries the TMDB api_key as a query parameter.
+        // Enable locally with: ./gradlew ... -PenableNetworkLogging=true
+        val enableNetworkLogging =
+            (project.findProperty("enableNetworkLogging") as? String)?.toBoolean() ?: false
+        buildConfigField(
+            FieldSpec.Type.BOOLEAN,
+            "ENABLE_NETWORK_LOGGING",
+            enableNetworkLogging.toString()
+        )
     }
 }

--- a/core/network/src/commonMain/kotlin/com/elna/moviedb/core/network/client/HttpClientConfig.kt
+++ b/core/network/src/commonMain/kotlin/com/elna/moviedb/core/network/client/HttpClientConfig.kt
@@ -1,5 +1,6 @@
 package com.elna.moviedb.core.network.client
 
+import com.elna.moviedb.core.network.BuildKonfig
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngineFactory
 import io.ktor.client.plugins.HttpTimeout
@@ -13,19 +14,23 @@ import kotlinx.serialization.json.Json
 fun createHttpClient(engine: HttpClientEngineFactory<*>) = HttpClient(engine) {
     install(ContentNegotiation) {
         json(Json {
-            prettyPrint = true
             isLenient = true
             ignoreUnknownKeys = true
         })
     }
 
-    install(Logging) {
-        logger = object : Logger {
-            override fun log(message: String) {
-                println("http client log = $message")
+    // Logging is gated behind a build flag because LogLevel.BODY logs the full
+    // request URL, which includes the TMDB api_key query parameter. Leaving it on
+    // would leak the key into release logs. Enable via -PenableNetworkLogging=true.
+    if (BuildKonfig.ENABLE_NETWORK_LOGGING) {
+        install(Logging) {
+            logger = object : Logger {
+                override fun log(message: String) {
+                    println("http client log = $message")
+                }
             }
+            level = LogLevel.BODY
         }
-        level = LogLevel.BODY
     }
 
     install(HttpTimeout) {

--- a/features/movies/src/commonMain/kotlin/com/elna/moviedb/feature/movies/model/MoviesUiAction.kt
+++ b/features/movies/src/commonMain/kotlin/com/elna/moviedb/feature/movies/model/MoviesUiAction.kt
@@ -6,7 +6,8 @@ package com.elna.moviedb.feature.movies.model
  */
 sealed interface MoviesUiAction {
     /**
-     * Show a pagination error snackbar with the given message
+     * Show a pagination error snackbar. The user-facing message is resolved from
+     * localized string resources at the UI layer — never carried as a raw string.
      */
-    data class ShowPaginationError(val message: String) : MoviesUiAction
+    data object ShowPaginationError : MoviesUiAction
 }

--- a/features/movies/src/commonMain/kotlin/com/elna/moviedb/feature/movies/ui/movies/MoviesScreen.kt
+++ b/features/movies/src/commonMain/kotlin/com/elna/moviedb/feature/movies/ui/movies/MoviesScreen.kt
@@ -44,6 +44,7 @@ import com.elna.moviedb.feature.movies.model.MoviesUiAction
 import com.elna.moviedb.feature.movies.model.MoviesUiState
 import com.elna.moviedb.resources.Res
 import com.elna.moviedb.resources.movies
+import com.elna.moviedb.resources.network_error
 import com.elna.moviedb.resources.now_playing_movies
 import com.elna.moviedb.resources.popular_movies
 import com.elna.moviedb.resources.top_rated_movies
@@ -83,6 +84,7 @@ private fun MoviesScreen(
     animatedVisibilityScope: AnimatedVisibilityScope? = null
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
+    val paginationErrorMessage = stringResource(Res.string.network_error)
 
     // Handle UI actions (one-time events)
     LaunchedEffect(Unit) {
@@ -90,7 +92,7 @@ private fun MoviesScreen(
             when (effect) {
                 is MoviesUiAction.ShowPaginationError -> {
                     snackbarHostState.showSnackbar(
-                        message = effect.message,
+                        message = paginationErrorMessage,
                         withDismissAction = true
                     )
                 }

--- a/features/movies/src/commonMain/kotlin/com/elna/moviedb/feature/movies/ui/movies/MoviesViewModel.kt
+++ b/features/movies/src/commonMain/kotlin/com/elna/moviedb/feature/movies/ui/movies/MoviesViewModel.kt
@@ -125,7 +125,7 @@ class MoviesViewModel(
 
                     // If we have movies, show snackbar; otherwise show error screen
                     if (currentMovies.isNotEmpty()) {
-                        _uiAction.send(MoviesUiAction.ShowPaginationError(result.message))
+                        _uiAction.send(MoviesUiAction.ShowPaginationError)
                     } else {
                         _uiState.update { it.copy(state = MoviesUiState.State.ERROR) }
                     }

--- a/features/tv-shows/src/commonMain/kotlin/com/elna/moviedb/feature/tvshows/model/TvShowsUiAction.kt
+++ b/features/tv-shows/src/commonMain/kotlin/com/elna/moviedb/feature/tvshows/model/TvShowsUiAction.kt
@@ -6,7 +6,8 @@ package com.elna.moviedb.feature.tvshows.model
  */
 sealed interface TvShowsUiAction {
     /**
-     * Show a pagination error snackbar with the given message
+     * Show a pagination error snackbar. The user-facing message is resolved from
+     * localized string resources at the UI layer — never carried as a raw string.
      */
-    data class ShowPaginationError(val message: String) : TvShowsUiAction
+    data object ShowPaginationError : TvShowsUiAction
 }

--- a/features/tv-shows/src/commonMain/kotlin/com/elna/moviedb/feature/tvshows/ui/tv_shows/TvShowsScreen.kt
+++ b/features/tv-shows/src/commonMain/kotlin/com/elna/moviedb/feature/tvshows/ui/tv_shows/TvShowsScreen.kt
@@ -31,6 +31,7 @@ import com.elna.moviedb.feature.tvshows.model.TvShowsUiAction
 import com.elna.moviedb.feature.tvshows.model.TvShowsUiState
 import com.elna.moviedb.feature.tvshows.ui.components.TvShowsSection
 import com.elna.moviedb.resources.Res
+import com.elna.moviedb.resources.network_error
 import com.elna.moviedb.resources.on_the_air_tv_shows
 import com.elna.moviedb.resources.popular_tv_shows
 import com.elna.moviedb.resources.top_rated_tv_shows
@@ -69,6 +70,7 @@ private fun TvShowsScreen(
     animatedVisibilityScope: AnimatedVisibilityScope? = null
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
+    val paginationErrorMessage = stringResource(Res.string.network_error)
 
     // Handle UI actions (one-time events)
     LaunchedEffect(Unit) {
@@ -76,7 +78,7 @@ private fun TvShowsScreen(
             when (effect) {
                 is TvShowsUiAction.ShowPaginationError -> {
                     snackbarHostState.showSnackbar(
-                        message = effect.message,
+                        message = paginationErrorMessage,
                         withDismissAction = true
                     )
                 }

--- a/features/tv-shows/src/commonMain/kotlin/com/elna/moviedb/feature/tvshows/ui/tv_shows/TvShowsViewModel.kt
+++ b/features/tv-shows/src/commonMain/kotlin/com/elna/moviedb/feature/tvshows/ui/tv_shows/TvShowsViewModel.kt
@@ -118,7 +118,7 @@ class TvShowsViewModel(
 
                     // If we have TV shows, show snackbar; otherwise show error screen
                     if (currentTvShows.isNotEmpty()) {
-                        _uiAction.send(TvShowsUiAction.ShowPaginationError(result.message))
+                        _uiAction.send(TvShowsUiAction.ShowPaginationError)
                     } else {
                         _uiState.update { it.copy(state = TvShowsUiState.State.ERROR) }
                     }


### PR DESCRIPTION
This commit addresses potential concurrency issues during language change registration, moves UI-facing strings out of ViewModels for better localization, and gates network logging to prevent API key leaks in production.

Key changes:
- **Language Coordination**: Updated `LanguageChangeCoordinator` to marshal listener registration onto a main-confined scope to avoid `ConcurrentModificationException`. Configured DI in `DataModule` to create repositories at startup, ensuring they register for language changes immediately.
- **Localization**: Refactored `MoviesUiAction` and `TvShowsUiAction` to remove raw string messages. Pagination errors are now resolved using localized string resources (`Res.string.network_error`) directly within the Compose screens.
- **Security**: Gated the Ktor `Logging` feature behind a new `ENABLE_NETWORK_LOGGING` build config field. Logging is now disabled by default and can be enabled via the `-PenableNetworkLogging=true` Gradle property to prevent sensitive TMDB API keys from appearing in release logs.
- **Navigation**: Improved stability in `AppState` by using `lastOrNull()` when accessing the navigation backstack to prevent potential crashes.
- **Network**: Simplified `HttpClient` configuration by removing unnecessary `prettyPrint` settings in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential crashes when the navigation back stack is empty
  * Improved thread-safety for listener registration in language change coordination

* **New Features**
  * Network logging can now be controlled via build configuration to prevent sensitive API key exposure in logs

* **Refactor**
  * Pagination error messages now use localized strings from app resources for consistent, translated error handling across movies and TV shows sections

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elnatand/cmp-moviedb/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->